### PR TITLE
style(ui): 更新gpu-calculator组件样式以支持深色模式

### DIFF
--- a/app/tools/gpu-calculator/page.tsx
+++ b/app/tools/gpu-calculator/page.tsx
@@ -264,28 +264,26 @@ export default function GPUCalculatorPage() {
             {result ? (
               <div className="space-y-4">
                 <div className="grid grid-cols-1 gap-4">
-                  <div className="p-4 bg-blue-50 rounded-lg">
-                    <h3 className="font-semibold text-blue-900">模型大小</h3>
-                    <p className="text-2xl font-bold text-blue-700">
+                  <div className="p-4 bg-blue-50 rounded-lg dark:bg-blue-900/20">
+                    <h3 className="font-semibold text-blue-900 dark:text-blue-200">模型大小</h3>
+                    <p className="text-2xl font-bold text-blue-700 dark:text-blue-300">
                       {result.modelSize} GB
                     </p>
                   </div>
-                  <div className="p-4 bg-green-50 rounded-lg">
-                    <h3 className="font-semibold text-green-900">
-                      键值缓存大小
-                    </h3>
-                    <p className="text-2xl font-bold text-green-700">
+                  <div className="p-4 bg-green-50 rounded-lg dark:bg-green-900/20">
+                    <h3 className="font-semibold text-green-900 dark:text-green-200">键值缓存大小</h3>
+                    <p className="text-2xl font-bold text-green-700 dark:text-green-300">
                       {result.kvCacheSize} GB
                     </p>
                   </div>
-                  <div className="p-4 bg-purple-50 rounded-lg">
-                    <h3 className="font-semibold text-purple-900">
+                  <div className="p-4 bg-purple-50 rounded-lg dark:bg-purple-900/20">
+                    <h3 className="font-semibold text-purple-900 dark:text-purple-200">
                       总显存需求
                     </h3>
-                    <p className="text-2xl font-bold text-purple-700">
+                    <p className="text-2xl font-bold text-purple-700 dark:text-purple-300">
                       {result.totalMemory} GB
                     </p>
-                    <p className="text-sm text-purple-600 mt-1">
+                    <p className="text-sm text-purple-600 dark:text-purple-400 mt-1">
                       已包含20%缓冲
                     </p>
                   </div>
@@ -300,9 +298,9 @@ export default function GPUCalculatorPage() {
                       {result.recommendedGPUs.map((gpu, index) => (
                         <div
                           key={index}
-                          className="flex justify-between items-center p-3 bg-gray-50 rounded-lg"
+                          className="flex justify-between items-center p-3 bg-gray-50 rounded-lg dark:bg-gray-800"
                         >
-                          <span className="font-medium">{gpu.name}</span>
+                          <span className="font-medium text-gray-900 dark:text-gray-100">{gpu.name}</span>
                           <Badge variant="secondary">{gpu.vram} GB</Badge>
                         </div>
                       ))}

--- a/app/tools/nat-type/page.tsx
+++ b/app/tools/nat-type/page.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+const STUN_SERVERS = [
+    "stun:stun.miwifi.com:3478",
+    "stun:stun.avigora.fr:3478",
+    "stun:stun.imp.ch:3478",
+    "stun:stun.root-1.de:3478",
+    "stun:stun.axialys.net:3478",
+    "stun:stun.sonetel.net:3478",
+    "stun:stun.skydrone.aero:3478",
+    "stun:stun.dcalling.de:3478",
+    "stun:stun.telnyx.com:3478",
+    "stun:stun.siptrunk.com:3478",
+    "stun:stun.romaaeterna.nl:3478",
+    "stun:stun.voipia.net:3478",
+    "stun:stun.nextcloud.com:443",
+    "stun:stun.m-online.net:3478",
+    "stun:stun.ringostat.com:3478",
+    "stun:stun.fitauto.ru:3478",
+    "stun:stun.cope.es:3478",
+    "stun:stun.nanocosmos.de:3478",
+    "stun:stun.streamnow.ch:3478",
+    "stun:stun.hot-chilli.net:3478",
+    "stun:stun.pure-ip.com:3478",
+    "stun:stun.radiojar.com:3478",
+    "stun:stun.sip.us:3478",
+];
+
+const NAT_TYPE_DESCRIPTION = [
+    {
+        type: "NAT1 - 全锥形NAT (Full Cone NAT)",
+        description: "这是最宽松的网络环境，IP和端口都不受限。\n\n• 任何外部主机都可以通过映射的公网IP和端口访问内网设备\n• 适合运行P2P应用和CDN业务\n• 可获得最佳的网络连接体验和业务收益"
+    },
+    {
+        type: "NAT2 - 受限锥型NAT (Address-Restricted Cone NAT)",
+        description: "相比NAT1增加了地址限制，IP受限但端口不受限。\n\n• 只有之前通信过的外部主机IP可以访问映射的端口\n• 仍能支持大多数P2P应用\n• 网络体验较好但不如NAT1开放"
+    },
+    {
+        type: "NAT3 - 端口受限锥型NAT (Port-Restricted Cone NAT)",
+        description: "相比NAT2又增加了端口限制，IP和端口都受限。\n\n• 只有之前通信过的外部主机IP和端口可以访问\n• 对P2P应用支持有限\n• 可能需要借助TURN服务器建立连接"
+    },
+    {
+        type: "NAT4 - 对称型NAT (Symmetric NAT)",
+        description: "最严格的NAT类型，基本上告别P2P。\n\n• 每个外部目标地址和端口都会创建新的映射\n• 请求不同外部地址时端口号可能不同\n• 除非具有IPv6地址，否则无法运行CDN业务\n• 游戏联机、视频通话等体验较差"
+    }
+];
+
+const NAT_OPTIMIZATION_TIPS = [
+    "若光猫为路由模式（光猫拨号），则电脑直连光猫，不再连接自己的路由器。",
+    "将光猫改为桥接模式，用路由器拨号。",
+    "换用其他运营商。移动宽带常出现局端限制NAT4，无论客户端如何修改也无济于事。联通和电信通常为NAT1，有些地区为公网，无NAT。",
+    "打开IPv6功能，不再纠结NAT类型。",
+    "针对学校、企业等网络，不要使用自己的路由器上网，使用交换机直连电脑，减少路由层数。"
+];
+
+export default function NatTypeCheckerPage() {
+    const [selectedServer, setSelectedServer] = useState(STUN_SERVERS[0]);
+    const [natType, setNatType] = useState<string | null>(null);
+    const [publicIp, setPublicIp] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [progress, setProgress] = useState(0);
+    const [error, setError] = useState<string | null>(null);
+
+    const detectNatType = async () => {
+        setIsLoading(true);
+        setNatType(null);
+        setPublicIp(null);
+        setError(null);
+        setProgress(0);
+
+        try {
+            const config = {
+                iceServers: [{ urls: selectedServer }],
+            };
+
+            const pc = new RTCPeerConnection(config);
+
+            pc.onicecandidate = (event) => {
+                if (event.candidate) {
+                    // Filter out non-host candidates for public IP discovery
+                    if (event.candidate.candidate.includes("typ srflx")) {
+                        const parts = event.candidate.candidate.split(" ");
+                        const ip = parts[4];
+                        setPublicIp(ip);
+                    }
+                    // For NAT type, we need to analyze multiple candidates and their types
+                    // This is a simplified approach. A full NAT type detection is complex.
+                    // For a more robust solution, consider a library like `nat-type-detector`
+                    // or a more detailed analysis of ICE candidates.
+                    if (event.candidate.type === "srflx") {
+                        setNatType("NAT1/2 - Full Cone NAT or Restricted Cone NAT");
+                    } else if (event.candidate.type === "prflx") {
+                        setNatType("NAT3 - Port Restricted Cone NAT");
+                    } else if (event.candidate.type === "relay") {
+                        setNatType("NAT4 - Symmetric NAT (via TURN server if available)");
+                    } else if (event.candidate.type === "host") {
+                        setNatType("NAT0 - No NAT (Public IP)");
+                    }
+                }
+            };
+
+            pc.onicegatheringstatechange = () => {
+                if (pc.iceGatheringState === "complete") {
+                    setIsLoading(false);
+                    setProgress(100);
+                    if (!natType) {
+                        setNatType("Unknown or Symmetric NAT (could not determine with STUN only)");
+                    }
+                } else if (pc.iceGatheringState === "gathering") {
+                    setProgress(50);
+                }
+            };
+
+            pc.oniceconnectionstatechange = () => {
+                if (pc.iceConnectionState === "failed") {
+                    setError("ICE connection failed. Could not determine NAT type.");
+                    setIsLoading(false);
+                    setProgress(100);
+                }
+            };
+
+            // Create a dummy data channel to trigger ICE candidate gathering
+            pc.createDataChannel("nat-check");
+            const offer = await pc.createOffer();
+            await pc.setLocalDescription(offer);
+
+            // Set a timeout for the detection process
+            setTimeout(() => {
+                if (isLoading) {
+                    setIsLoading(false);
+                    setProgress(100);
+                    if (!natType) {
+                        setError("Detection timed out. Could not determine NAT type.");
+                    }
+                    pc.close();
+                }
+            }, 10000); // 10 seconds timeout
+
+        } catch (err) {
+            console.error("Error during NAT detection:", err);
+            setError("An error occurred during detection. Please try again.");
+            setIsLoading(false);
+            setProgress(100);
+        }
+    };
+
+    return (
+        <div className="container relative">
+            <div className="mx-auto py-10">
+                <h1 className="font-heading text-3xl md:text-4xl">NAT类型检测工具</h1>
+
+                <div className="pt-10">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>NAT类型检测</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="space-y-2">
+                                <p>选择STUN服务器:</p>
+                                <Select value={selectedServer} onValueChange={setSelectedServer}>
+                                    <SelectTrigger className="w-full">
+                                        <SelectValue placeholder="选择STUN服务器" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {STUN_SERVERS.map((serverUrl) => (
+                                            <SelectItem key={serverUrl} value={serverUrl}>
+                                                {serverUrl}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+
+                            <Button onClick={detectNatType} disabled={isLoading}>
+                                {isLoading ? "检测中..." : "开始检测NAT类型"}
+                            </Button>
+
+                            {isLoading && (
+                                <div className="space-y-2">
+                                    <Progress value={progress} className="w-full" />
+                                    <p className="text-sm text-muted-foreground">Gathering ICE candidates...</p>
+                                </div>
+                            )}
+                            {error && (
+                                <p className="text-red-500">错误: {error}</p>
+                            )}
+                            {natType && (
+                                <div>
+                                    <h3 className="font-semibold">检测到的NAT类型:</h3>
+                                    <p>{natType}</p>
+                                </div>
+                            )}
+                            {publicIp && (
+                                <div>
+                                    <h3 className="font-semibold">公网IP地址:</h3>
+                                    <p>{publicIp}</p>
+                                </div>
+                            )}
+                            <p className="text-sm text-muted-foreground">
+                                注意: 仅使用STUN服务器检测NAT类型可能不够准确，特别是对于对称NAT。如需更精确的结果，可能需要使用TURN服务器。
+                            </p>
+
+                        </CardContent>
+                    </Card>
+                </div>
+
+                <div className="mt-10">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>NAT类型详解</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="grid gap-4 md:grid-cols-2">
+                                {NAT_TYPE_DESCRIPTION.map((nat) => (
+                                    <Card key={nat.type} className="p-4 border rounded-lg hover:shadow-md transition-shadow">
+                                        <h4 className="font-medium text-lg mb-2">{nat.type}</h4>
+                                        <p className="text-sm text-muted-foreground whitespace-pre-line">
+                                            {nat.description}
+                                        </p>
+                                    </Card>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </Card>
+                </div>
+
+                <div className="mt-10">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>如何优化NAT类型</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <ul className="list-disc pl-5 space-y-2 text-base">
+                                {NAT_OPTIMIZATION_TIPS.map((tip, index) => (
+                                    <li key={index}>{tip}</li>
+                                ))}
+                            </ul>
+                        </CardContent>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/tools/nat-type/page.tsx
+++ b/app/tools/nat-type/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";

--- a/app/tools/network-info/page.tsx
+++ b/app/tools/network-info/page.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+interface NetworkInfo {
+    ipAddress?: string;
+    country?: string;
+    countryCode?: string;
+    region?: string;
+    regionName?: string;
+    city?: string;
+    zip?: string;
+    lat?: number;
+    lon?: number;
+    timezone?: string;
+    isp?: string;
+    org?: string;
+    asn?: string;
+    as?: string;
+    query?: string;
+}
+
+interface SiteTestResult {
+    url: string;
+    status: "idle" | "testing" | "success" | "failed";
+    latency: number | null;
+    error: string | null;
+}
+
+interface PredefinedSite {
+    name: string;
+    logo: string;
+    url: string;
+    type: "domestic" | "international";
+}
+
+const predefinedSites: PredefinedSite[] = [
+    { name: "Google", logo: "https://www.google.com/favicon.ico", url: "https://www.google.com", type: "international" },
+    { name: "GitHub", logo: "https://github.githubassets.com/favicons/favicon.svg", url: "https://www.github.com", type: "international" },
+    { name: "Bilibili", logo: "https://www.bilibili.com/favicon.ico", url: "https://www.bilibili.com", type: "domestic" },
+    { name: "OpenAI", logo: "https://openai.com/favicon.ico", url: "https://openai.com", type: "international" },
+    { name: "X (Twitter)", logo: "https://abs.twimg.com/favicons/twitter.2.ico", url: "https://x.com", type: "international" },
+    { name: "Weibo", logo: "https://weibo.com/favicon.ico", url: "https://weibo.com", type: "domestic" },
+    { name: "YouTube", logo: "https://www.youtube.com/favicon.ico", url: "https://www.youtube.com", type: "international" },
+    { name: "Douyin", logo: "https://lf1-cdn-tos.bytegoofy.com/goofy/ies/douyin_web/public/favicon.ico", url: "https://www.douyin.com", type: "domestic" },
+    { name: "TikTok", logo: "https://www.tiktok.com/favicon.ico", url: "https://www.tiktok.com", type: "international" },
+];
+
+export default function NetworkInfoPage() {
+    const [networkInfo, setNetworkInfo] = useState<NetworkInfo | null>(null);
+    const [loading, setLoading] = useState<boolean>(false);
+    const [progress, setProgress] = useState<number>(0);
+    const [apiSource, setApiSource] = useState<"ip.sb" | "ip-api.com">("ip.sb");
+    const [error, setError] = useState<string | null>(null);
+    const [siteTestResults, setSiteTestResults] = useState<SiteTestResult[]>(() =>
+        predefinedSites.map((site) => ({ url: site.url, status: "idle", latency: null, error: null }))
+    );
+    const [testingAllSites, setTestingAllSites] = useState<boolean>(false);
+
+    const fetchNetworkInfo = async (source: "ip.sb" | "ip-api.com") => {
+        setLoading(true);
+        setProgress(0);
+        setNetworkInfo(null);
+        setError(null);
+
+        try {
+            let data: NetworkInfo = {};
+            if (source === "ip.sb") {
+                setProgress(30);
+                const ipSbResponse = await fetch("https://api.ip.sb/geoip");
+                if (!ipSbResponse.ok) {
+                    throw new Error(`IP.SB API error: ${ipSbResponse.statusText}`);
+                }
+                const ipSbData = await ipSbResponse.json();
+                data = {
+                    ipAddress: ipSbData.ip,
+                    country: ipSbData.country,
+                    countryCode: ipSbData.country_code,
+                    city: ipSbData.city,
+                    lat: ipSbData.latitude,
+                    lon: ipSbData.longitude,
+                    timezone: ipSbData.timezone,
+                    isp: ipSbData.isp,
+                    org: ipSbData.organization,
+                    asn: ipSbData.asn_organization,
+                    query: ipSbData.ip,
+                };
+            } else {
+                setProgress(30);
+                const ipApiComResponse = await fetch("http://ip-api.com/json");
+                if (!ipApiComResponse.ok) {
+                    throw new Error(`IP-API.com error: ${ipApiComResponse.statusText}`);
+                }
+                const ipApiComData = await ipApiComResponse.json();
+                if (ipApiComData.status === "fail") {
+                    throw new Error(`IP-API.com status: ${ipApiComData.message}`);
+                }
+                data = {
+                    ipAddress: ipApiComData.query,
+                    country: ipApiComData.country,
+                    countryCode: ipApiComData.countryCode,
+                    region: ipApiComData.region,
+                    regionName: ipApiComData.regionName,
+                    city: ipApiComData.city,
+                    zip: ipApiComData.zip,
+                    lat: ipApiComData.lat,
+                    lon: ipApiComData.lon,
+                    timezone: ipApiComData.timezone,
+                    isp: ipApiComData.isp,
+                    org: ipApiComData.org,
+                    asn: ipApiComData.as,
+                    query: ipApiComData.query,
+                };
+            }
+            setNetworkInfo(data);
+            setProgress(100);
+        } catch (err) {
+            console.error("获取网络信息失败:", err);
+            setError(`获取网络信息失败: ${(err as Error).message}`);
+            setProgress(0);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const testSiteConnectivity = async (url: string) => {
+        setSiteTestResults((prevResults) =>
+            prevResults.map((result) =>
+                result.url === url ? { ...result, status: "testing", latency: null, error: null } : result
+            )
+        );
+        const startTime = performance.now();
+        try {
+            const response = await fetch(url, { mode: 'no-cors' }); // Use no-cors for basic reachability
+            const endTime = performance.now();
+            const latency = Math.round(endTime - startTime);
+            setSiteTestResults((prevResults) =>
+                prevResults.map((result) =>
+                    result.url === url
+                        ? { ...result, status: "success", latency, error: null }
+                        : result
+                )
+            );
+        } catch (err) {
+            const endTime = performance.now();
+            const latency = Math.round(endTime - startTime);
+            setSiteTestResults((prevResults) =>
+                prevResults.map((result) =>
+                    result.url === url
+                        ? { ...result, status: "failed", latency, error: (err as Error).message }
+                        : result
+                )
+            );
+        }
+    };
+
+    const testAllSites = async () => {
+        setTestingAllSites(true);
+        setSiteTestResults(predefinedSites.map((site) => ({ url: site.url, status: "idle", latency: null, error: null })));
+        for (const site of predefinedSites) {
+            await testSiteConnectivity(site.url);
+        }
+        setTestingAllSites(false);
+    };
+
+    useEffect(() => {
+        fetchNetworkInfo(apiSource);
+    }, [apiSource]);
+
+    const domesticSites = predefinedSites.filter(site => site.type === "domestic");
+    const internationalSites = predefinedSites.filter(site => site.type === "international");
+
+    const renderSiteBadges = (sites: PredefinedSite[]) => (
+        <div className="mb-4 flex flex-wrap gap-2">
+            {sites.map((site) => {
+                const result = siteTestResults.find((r) => r.url === site.url);
+                let variant: "default" | "secondary" | "outline" | "destructive" | "success" | null = "secondary";
+                let pingText = "";
+
+                if (result) {
+                    if (result.status === "testing") {
+                        variant = "outline";
+                        pingText = "测试中...";
+                    } else if (result.status === "success") {
+                        variant = "success";
+                        pingText = `${result.latency}ms`;
+                    } else if (result.status === "failed") {
+                        variant = "destructive";
+                        pingText = "失败";
+                    }
+                }
+
+                return (
+                    <Badge
+                        key={site.url}
+                        variant="secondary"
+                        className="cursor-pointer flex items-center space-x-1 pr-3"
+                        onClick={() => !testingAllSites && testSiteConnectivity(site.url)}
+                    >
+                        <img src={site.logo} alt={site.name} className="w-4 h-4 rounded-full" />
+                        <span>{site.name}</span>
+                        {pingText && <span className="ml-2 text-xs opacity-75">{pingText}</span>}
+                    </Badge>
+                );
+            })}
+        </div>
+    );
+
+    return (
+        <div className="container mx-auto p-4">
+            <h1 className="text-2xl font-bold mb-4">网络信息相关</h1>
+
+            <Card className="mb-4">
+                <CardHeader>
+                    <CardTitle>网络信息查询</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <div className="mb-4 flex space-x-2">
+                        <Button
+                            onClick={() => setApiSource("ip.sb")}
+                            disabled={loading}
+                            variant={apiSource === "ip.sb" ? "default" : "outline"}
+                        >
+                            使用 IP.SB API
+                        </Button>
+                        <Button
+                            onClick={() => setApiSource("ip-api.com")}
+                            disabled={loading}
+                            variant={apiSource === "ip-api.com" ? "default" : "outline"}
+                        >
+                            使用 IP-API.com API
+                        </Button>
+                    </div>
+
+                    {loading && (
+                        <div className="mb-4">
+                            <p className="mb-2">正在获取网络信息...</p>
+                            <Progress value={progress} className="w-full" />
+                        </div>
+                    )}
+
+                    {error && (
+                        <Card className="mb-4 border-red-500 bg-red-50/50">
+                            <CardHeader>
+                                <CardTitle className="text-red-700">错误</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <p className="text-red-600">{error}</p>
+                            </CardContent>
+                        </Card>
+                    )}
+
+                    {networkInfo && !loading && !error && (
+                        <Card className="mb-4">
+                            <CardHeader>
+                                <CardTitle>您的网络信息</CardTitle>
+                            </CardHeader>
+                            <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <div className="flex items-center">
+                                    <span className="font-semibold mr-2">IP 地址:</span>
+                                    <Badge variant="secondary">{networkInfo.ipAddress}</Badge>
+                                </div>
+                                <div className="flex items-center">
+                                    <span className="font-semibold mr-2">国家:</span>
+                                    <Badge variant="secondary">
+                                        {networkInfo.country} ({networkInfo.countryCode})
+                                    </Badge>
+                                </div>
+                                {networkInfo.regionName && (
+                                    <div className="flex items-center">
+                                        <span className="font-semibold mr-2">区域:</span>
+                                        <Badge variant="secondary">
+                                            {networkInfo.regionName} ({networkInfo.region})
+                                        </Badge>
+                                    </div>
+                                )}
+                                {networkInfo.city && (
+                                    <div className="flex items-center">
+                                        <span className="font-semibold mr-2">城市:</span>
+                                        <Badge variant="secondary">{networkInfo.city}</Badge>
+                                    </div>
+                                )}
+                                {networkInfo.zip && (
+                                    <div className="flex items-center">
+                                        <span className="font-semibold mr-2">邮编:</span>
+                                        <Badge variant="secondary">{networkInfo.zip}</Badge>
+                                    </div>
+                                )}
+                                {(networkInfo.lat || networkInfo.lon) && (
+                                    <div className="flex items-center">
+                                        <span className="font-semibold mr-2">经纬度:</span>
+                                        <Badge variant="secondary">
+                                            {networkInfo.lat}, {networkInfo.lon}
+                                        </Badge>
+                                    </div>
+                                )}
+                                {networkInfo.timezone && (
+                                    <div className="flex items-center">
+                                        <span className="font-semibold mr-2">时区:</span>
+                                        <Badge variant="secondary">{networkInfo.timezone}</Badge>
+                                    </div>
+                                )}
+                                {networkInfo.isp && (
+                                    <div className="flex items-center">
+                                        <span className="font-semibold mr-2">ISP:</span>
+                                        <Badge variant="secondary">{networkInfo.isp}</Badge>
+                                    </div>
+                                )}
+                                {networkInfo.org && (
+                                    <div className="flex items-center">
+                                        <span className="font-semibold mr-2">组织:</span>
+                                        <Badge variant="secondary">{networkInfo.org}</Badge>
+                                    </div>
+                                )}
+                                {networkInfo.asn && (
+                                    <div className="flex items-center">
+                                        <span className="font-semibold mr-2">ASN:</span>
+                                        <Badge variant="secondary">{networkInfo.asn}</Badge>
+                                    </div>
+                                )}
+                            </CardContent>
+                        </Card>
+                    )}
+                </CardContent>
+            </Card>
+
+            <Card className="mb-4">
+                <CardHeader>
+                    <CardTitle>站点连通性测试</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Button onClick={testAllSites} disabled={testingAllSites}>
+                        {testingAllSites ? "正在测试所有站点..." : "一键全部测试"}
+                    </Button>
+                    <h3 className="text-lg font-semibold mb-2 mt-4">国内站点</h3>
+                    {renderSiteBadges(domesticSites)}
+                    <h3 className="text-lg font-semibold mb-2 mt-4">海外站点</h3>
+                    {renderSiteBadges(internationalSites)}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/app/tools/network-info/page.tsx
+++ b/app/tools/network-info/page.tsx
@@ -55,7 +55,7 @@ export default function NetworkInfoPage() {
     const [networkInfo, setNetworkInfo] = useState<NetworkInfo | null>(null);
     const [loading, setLoading] = useState<boolean>(false);
     const [progress, setProgress] = useState<number>(0);
-    const [apiSource, setApiSource] = useState<"ip.sb" | "ip-api.com">("ip.sb");
+    const [apiSource] = useState<"ip.sb" | "ip-api.com">("ip.sb");
     const [error, setError] = useState<string | null>(null);
     const [siteTestResults, setSiteTestResults] = useState<SiteTestResult[]>(() =>
         predefinedSites.map((site) => ({ url: site.url, status: "idle", latency: null, error: null }))
@@ -211,39 +211,102 @@ export default function NetworkInfoPage() {
         </div>
     );
 
-
     return (
         <div className="container mx-auto p-4">
-            <h1 className="text-3xl font-bold text-center mb-6">网络信息与连通性测试</h1>
+            <h1 className="text-3xl font-bold text-center mb-6">网络信息数据获取与测试</h1>
 
             {/* Network Info Card */}
             <Card className="mb-6">
                 <CardHeader>
-                    <CardTitle>我的网络信息</CardTitle>
+                    <CardTitle>网络信息</CardTitle>
                 </CardHeader>
                 <CardContent>
-                    {loading && <Progress value={progress} className="w-full mb-4" />}
-                    {error && <p className="text-red-500 mb-4">错误: {error}</p>}
-                    {networkInfo ? (
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-                            <div>
-                                <p><strong>IP 地址:</strong> {networkInfo.ipAddress}</p>
-                                <p><strong>国家:</strong> {networkInfo.country} ({networkInfo.countryCode})</p>
-                                <p><strong>地区:</strong> {networkInfo.regionName || networkInfo.region}</p>
-                                <p><strong>城市:</strong> {networkInfo.city}</p>
-                                <p><strong>邮编:</strong> {networkInfo.zip}</p>
-                            </div>
-                            <div>
-                                <p><strong>经纬度:</strong> {networkInfo.lat}, {networkInfo.lon}</p>
-                                <p><strong>时区:</strong> {networkInfo.timezone}</p>
-                                <p><strong>ISP:</strong> {networkInfo.isp}</p>
-                                <p><strong>组织:</strong> {networkInfo.org}</p>
-                                <p><strong>ASN:</strong> {networkInfo.asn}</p>
-                            </div>
+                    <p className="mb-4 text-sm text-gray-600">通过API接口获取网络信息。</p>
+                    {loading && (
+                        <div className="mb-4">
+                            <p className="mb-2">正在获取网络信息...</p>
+                            <Progress value={progress} className="w-full" />
                         </div>
-                    ) : (
-                        !loading && !error && <p>点击按钮获取网络信息。</p>
                     )}
+
+                    {error && (
+                        <Card className="mb-4 border-red-500 bg-red-50/50">
+                            <CardHeader>
+                                <CardTitle className="text-red-700">错误</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <p className="text-red-600">{error}</p>
+                            </CardContent>
+                        </Card>
+                    )}
+
+                    {networkInfo && !loading && !error && (
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div className="flex items-center">
+                                <span className="font-semibold mr-2">IP 地址:</span>
+                                <Badge variant="secondary">{networkInfo.ipAddress}</Badge>
+                            </div>
+                            <div className="flex items-center">
+                                <span className="font-semibold mr-2">国家:</span>
+                                <Badge variant="secondary">
+                                    {networkInfo.country} ({networkInfo.countryCode})
+                                </Badge>
+                            </div>
+                            {networkInfo.regionName && (
+                                <div className="flex items-center">
+                                    <span className="font-semibold mr-2">区域:</span>
+                                    <Badge variant="secondary">
+                                        {networkInfo.regionName} ({networkInfo.region})
+                                    </Badge>
+                                </div>
+                            )}
+                            {networkInfo.city && (
+                                <div className="flex items-center">
+                                    <span className="font-semibold mr-2">城市:</span>
+                                    <Badge variant="secondary">{networkInfo.city}</Badge>
+                                </div>
+                            )}
+                            {networkInfo.zip && (
+                                <div className="flex items-center">
+                                    <span className="font-semibold mr-2">邮编:</span>
+                                    <Badge variant="secondary">{networkInfo.zip}</Badge>
+                                </div>
+                            )}
+                            {(networkInfo.lat || networkInfo.lon) && (
+                                <div className="flex items-center">
+                                    <span className="font-semibold mr-2">经纬度:</span>
+                                    <Badge variant="secondary">
+                                        {networkInfo.lat}, {networkInfo.lon}
+                                    </Badge>
+                                </div>
+                            )}
+                            {networkInfo.timezone && (
+                                <div className="flex items-center">
+                                    <span className="font-semibold mr-2">时区:</span>
+                                    <Badge variant="secondary">{networkInfo.timezone}</Badge>
+                                </div>
+                            )}
+                            {networkInfo.isp && (
+                                <div className="flex items-center">
+                                    <span className="font-semibold mr-2">ISP:</span>
+                                    <Badge variant="secondary">{networkInfo.isp}</Badge>
+                                </div>
+                            )}
+                            {networkInfo.org && (
+                                <div className="flex items-center">
+                                    <span className="font-semibold mr-2">组织:</span>
+                                    <Badge variant="secondary">{networkInfo.org}</Badge>
+                                </div>
+                            )}
+                            {networkInfo.asn && (
+                                <div className="flex items-center">
+                                    <span className="font-semibold mr-2">ASN:</span>
+                                    <Badge variant="secondary">{networkInfo.asn}</Badge>
+                                </div>
+                            )}
+                        </div>
+                    )}
+
                     <div className="mt-4 flex space-x-2">
                         <Button onClick={() => fetchNetworkInfo("ip.sb")} disabled={loading}>
                             {loading && apiSource === "ip.sb" ? "获取中..." : "使用 IP.SB 获取"}
@@ -252,6 +315,7 @@ export default function NetworkInfoPage() {
                             {loading && apiSource === "ip-api.com" ? "获取中..." : "使用 IP-API.com 获取"}
                         </Button>
                     </div>
+
                 </CardContent>
             </Card>
 

--- a/app/tools/network-info/page.tsx
+++ b/app/tools/network-info/page.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import Image from "next/image";
+import { Input } from "@/components/ui/input";
 
 interface NetworkInfo {
     ipAddress?: string;
@@ -202,7 +202,7 @@ export default function NetworkInfoPage() {
                         className="cursor-pointer flex items-center space-x-1 pr-3"
                         onClick={() => !testingAllSites && testSiteConnectivity(site.url)}
                     >
-                        <Image src={site.logo} alt={site.name} width={16} height={16} className="w-4 h-4 rounded-full" /> {/* Replace <img> with <Image /> */}
+                        <img src={site.logo} alt={site.name} className="w-4 h-4 rounded-full" />
                         <span>{site.name}</span>
                         {pingText && <span className="ml-2 text-xs opacity-75">{pingText}</span>}
                     </Badge>
@@ -211,138 +211,205 @@ export default function NetworkInfoPage() {
         </div>
     );
 
+
     return (
         <div className="container mx-auto p-4">
-            <h1 className="text-2xl font-bold mb-4">网络信息相关</h1>
+            <h1 className="text-3xl font-bold text-center mb-6">网络信息与连通性测试</h1>
 
-            <Card className="mb-4">
+            {/* Network Info Card */}
+            <Card className="mb-6">
                 <CardHeader>
-                    <CardTitle>网络信息查询</CardTitle>
+                    <CardTitle>我的网络信息</CardTitle>
                 </CardHeader>
                 <CardContent>
-                    <div className="mb-4 flex space-x-2">
-                        <Button
-                            onClick={() => setApiSource("ip.sb")}
-                            disabled={loading}
-                            variant={apiSource === "ip.sb" ? "default" : "outline"}
-                        >
-                            使用 IP.SB API
+                    {loading && <Progress value={progress} className="w-full mb-4" />}
+                    {error && <p className="text-red-500 mb-4">错误: {error}</p>}
+                    {networkInfo ? (
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+                            <div>
+                                <p><strong>IP 地址:</strong> {networkInfo.ipAddress}</p>
+                                <p><strong>国家:</strong> {networkInfo.country} ({networkInfo.countryCode})</p>
+                                <p><strong>地区:</strong> {networkInfo.regionName || networkInfo.region}</p>
+                                <p><strong>城市:</strong> {networkInfo.city}</p>
+                                <p><strong>邮编:</strong> {networkInfo.zip}</p>
+                            </div>
+                            <div>
+                                <p><strong>经纬度:</strong> {networkInfo.lat}, {networkInfo.lon}</p>
+                                <p><strong>时区:</strong> {networkInfo.timezone}</p>
+                                <p><strong>ISP:</strong> {networkInfo.isp}</p>
+                                <p><strong>组织:</strong> {networkInfo.org}</p>
+                                <p><strong>ASN:</strong> {networkInfo.asn}</p>
+                            </div>
+                        </div>
+                    ) : (
+                        !loading && !error && <p>点击按钮获取网络信息。</p>
+                    )}
+                    <div className="mt-4 flex space-x-2">
+                        <Button onClick={() => fetchNetworkInfo("ip.sb")} disabled={loading}>
+                            {loading && apiSource === "ip.sb" ? "获取中..." : "使用 IP.SB 获取"}
                         </Button>
-                        <Button
-                            onClick={() => setApiSource("ip-api.com")}
-                            disabled={loading}
-                            variant={apiSource === "ip-api.com" ? "default" : "outline"}
-                        >
-                            使用 IP-API.com API
+                        <Button onClick={() => fetchNetworkInfo("ip-api.com")} disabled={loading}>
+                            {loading && apiSource === "ip-api.com" ? "获取中..." : "使用 IP-API.com 获取"}
                         </Button>
                     </div>
-
-                    {loading && (
-                        <div className="mb-4">
-                            <p className="mb-2">正在获取网络信息...</p>
-                            <Progress value={progress} className="w-full" />
-                        </div>
-                    )}
-
-                    {error && (
-                        <Card className="mb-4 border-red-500 bg-red-50/50">
-                            <CardHeader>
-                                <CardTitle className="text-red-700">错误</CardTitle>
-                            </CardHeader>
-                            <CardContent>
-                                <p className="text-red-600">{error}</p>
-                            </CardContent>
-                        </Card>
-                    )}
-
-                    {networkInfo && !loading && !error && (
-                        <Card className="mb-4">
-                            <CardHeader>
-                                <CardTitle>您的网络信息</CardTitle>
-                            </CardHeader>
-                            <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <div className="flex items-center">
-                                    <span className="font-semibold mr-2">IP 地址:</span>
-                                    <Badge variant="secondary">{networkInfo.ipAddress}</Badge>
-                                </div>
-                                <div className="flex items-center">
-                                    <span className="font-semibold mr-2">国家:</span>
-                                    <Badge variant="secondary">
-                                        {networkInfo.country} ({networkInfo.countryCode})
-                                    </Badge>
-                                </div>
-                                {networkInfo.regionName && (
-                                    <div className="flex items-center">
-                                        <span className="font-semibold mr-2">区域:</span>
-                                        <Badge variant="secondary">
-                                            {networkInfo.regionName} ({networkInfo.region})
-                                        </Badge>
-                                    </div>
-                                )}
-                                {networkInfo.city && (
-                                    <div className="flex items-center">
-                                        <span className="font-semibold mr-2">城市:</span>
-                                        <Badge variant="secondary">{networkInfo.city}</Badge>
-                                    </div>
-                                )}
-                                {networkInfo.zip && (
-                                    <div className="flex items-center">
-                                        <span className="font-semibold mr-2">邮编:</span>
-                                        <Badge variant="secondary">{networkInfo.zip}</Badge>
-                                    </div>
-                                )}
-                                {(networkInfo.lat || networkInfo.lon) && (
-                                    <div className="flex items-center">
-                                        <span className="font-semibold mr-2">经纬度:</span>
-                                        <Badge variant="secondary">
-                                            {networkInfo.lat}, {networkInfo.lon}
-                                        </Badge>
-                                    </div>
-                                )}
-                                {networkInfo.timezone && (
-                                    <div className="flex items-center">
-                                        <span className="font-semibold mr-2">时区:</span>
-                                        <Badge variant="secondary">{networkInfo.timezone}</Badge>
-                                    </div>
-                                )}
-                                {networkInfo.isp && (
-                                    <div className="flex items-center">
-                                        <span className="font-semibold mr-2">ISP:</span>
-                                        <Badge variant="secondary">{networkInfo.isp}</Badge>
-                                    </div>
-                                )}
-                                {networkInfo.org && (
-                                    <div className="flex items-center">
-                                        <span className="font-semibold mr-2">组织:</span>
-                                        <Badge variant="secondary">{networkInfo.org}</Badge>
-                                    </div>
-                                )}
-                                {networkInfo.asn && (
-                                    <div className="flex items-center">
-                                        <span className="font-semibold mr-2">ASN:</span>
-                                        <Badge variant="secondary">{networkInfo.asn}</Badge>
-                                    </div>
-                                )}
-                            </CardContent>
-                        </Card>
-                    )}
                 </CardContent>
             </Card>
 
-            <Card className="mb-4">
+            {/* Site Connectivity Test Card */}
+            <Card className="mb-6">
                 <CardHeader>
-                    <CardTitle>站点连通性测试</CardTitle>
+                    <CardTitle>网站连通性测试</CardTitle>
                 </CardHeader>
                 <CardContent>
+                    <p className="mb-4 text-sm text-gray-600">测试常用网站的连通性和延迟。</p>
+                    <div className="mb-4">
+                        <h3 className="text-lg font-semibold mb-2">国内网站:</h3>
+                        {renderSiteBadges(domesticSites)}
+                    </div>
+                    <div className="mb-4">
+                        <h3 className="text-lg font-semibold mb-2">国际网站:</h3>
+                        {renderSiteBadges(internationalSites)}
+                    </div>
                     <Button onClick={testAllSites} disabled={testingAllSites}>
-                        {testingAllSites ? "正在测试所有站点..." : "一键全部测试"}
+                        {testingAllSites ? "测试中..." : "测试所有网站"}
                     </Button>
-                    <h3 className="text-lg font-semibold mb-2 mt-4">国内站点</h3>
-                    {renderSiteBadges(domesticSites)}
-                    <h3 className="text-lg font-semibold mb-2 mt-4">海外站点</h3>
-                    {renderSiteBadges(internationalSites)}
                 </CardContent>
             </Card>
+
+            {/* WebSocket Test Card */}
+            <WebSocketTestCard />
         </div>
+    );
+}
+
+interface WebSocketTestResult {
+    url: string;
+    status: "idle" | "connecting" | "open" | "closed" | "error";
+    message: string;
+    latency: number | null;
+}
+
+function WebSocketTestCard() {
+    const [wsUrl, setWsUrl] = useState<string>("wss://echo.websocket.events");
+    const [wsTestResult, setWsTestResult] = useState<WebSocketTestResult | null>(null);
+    const [messageToSend, setMessageToSend] = useState<string>("Hello WebSocket");
+    const [wsInstance, setWsInstance] = useState<WebSocket | null>(null);
+
+    const testWebSocket = () => {
+        if (wsInstance) {
+            wsInstance.close();
+        }
+
+        setWsTestResult({ url: wsUrl, status: "connecting", message: "", latency: null });
+        const startTime = performance.now();
+
+        try {
+            const ws = new WebSocket(wsUrl);
+            setWsInstance(ws);
+
+            ws.onopen = () => {
+                const latency = Math.round(performance.now() - startTime);
+                setWsTestResult({ url: wsUrl, status: "open", message: "连接成功！", latency });
+            };
+
+            ws.onmessage = (event) => {
+                setWsTestResult((prev) => ({
+                    ...(prev || { url: wsUrl, status: "open", message: "", latency: null }),
+                    message: `收到消息: ${event.data}`,
+                }));
+            };
+
+            ws.onclose = () => {
+                setWsTestResult((prev) => ({
+                    ...(prev || { url: wsUrl, status: "closed", message: "", latency: null }),
+                    status: "closed",
+                    message: "连接已关闭。",
+                }));
+            };
+
+            ws.onerror = (error) => {
+                console.error("WebSocket 错误:", error);
+                setWsTestResult({ url: wsUrl, status: "error", message: "连接错误！", latency: null });
+            };
+        } catch (err) {
+            setWsTestResult({ url: wsUrl, status: "error", message: `创建连接失败: ${(err as Error).message}`, latency: null });
+        }
+    };
+
+    const sendMessage = () => {
+        if (wsInstance && wsInstance.readyState === WebSocket.OPEN) {
+            wsInstance.send(messageToSend);
+            setWsTestResult((prev) => ({
+                ...(prev || { url: wsUrl, status: "open", message: "", latency: null }),
+                message: `已发送: ${messageToSend}`,
+            }));
+        } else {
+            setWsTestResult((prev) => ({
+                ...(prev || { url: wsUrl, status: "idle", message: "", latency: null }),
+                message: "WebSocket 未连接或已关闭，无法发送消息。",
+                status: "error",
+            }));
+        }
+    };
+
+    const closeWebSocket = () => {
+        if (wsInstance) {
+            wsInstance.close();
+            setWsInstance(null);
+        }
+    };
+
+    return (
+        <Card className="mb-6">
+            <CardHeader>
+                <CardTitle>WebSocket 连接测试</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <p className="mb-4 text-sm text-gray-600">测试 WebSocket 服务器的连通性。</p>
+                <div className="flex items-center space-x-2 mb-4">
+                    <Input
+                        type="text"
+                        placeholder="WebSocket URL (e.g., wss://echo.websocket.events)"
+                        value={wsUrl}
+                        onChange={(e) => setWsUrl(e.target.value)}
+                        className="flex-grow"
+                    />
+                    <Button onClick={testWebSocket} disabled={wsTestResult?.status === "connecting"}>
+                        {wsTestResult?.status === "connecting" ? "连接中..." : "连接"}
+                    </Button>
+                    <Button onClick={closeWebSocket} disabled={!wsInstance || wsInstance.readyState !== WebSocket.OPEN} variant="outline">
+                        断开
+                    </Button>
+                </div>
+
+                {wsTestResult && (
+                    <div className="mb-4 p-3 border rounded-md">
+                        <div><strong>状态:</strong>
+                            {wsTestResult.status === "connecting" && <Badge variant="outline">连接中</Badge>}
+                            {wsTestResult.status === "open" && <Badge variant="default">已连接</Badge>}
+                            {wsTestResult.status === "closed" && <Badge variant="secondary">已关闭</Badge>}
+                            {wsTestResult.status === "error" && <Badge variant="destructive">错误</Badge>}
+                            {wsTestResult.status === "idle" && <Badge variant="outline">空闲</Badge>}
+                        </div>
+                        {wsTestResult.latency !== null && <p><strong>延迟:</strong> {wsTestResult.latency}ms</p>}
+                        {wsTestResult.message && <p><strong>消息:</strong> {wsTestResult.message}</p>}
+                    </div>
+                )}
+
+                <div className="flex items-center space-x-2">
+                    <Input
+                        type="text"
+                        placeholder="要发送的消息"
+                        value={messageToSend}
+                        onChange={(e) => setMessageToSend(e.target.value)}
+                        className="flex-grow"
+                        disabled={!wsInstance || wsInstance.readyState !== WebSocket.OPEN}
+                    />
+                    <Button onClick={sendMessage} disabled={!wsInstance || wsInstance.readyState !== WebSocket.OPEN}>
+                        发送消息
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
     );
 }

--- a/app/tools/network-info/page.tsx
+++ b/app/tools/network-info/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import Image from "next/image";
 
 interface NetworkInfo {
     ipAddress?: string;
@@ -135,7 +136,7 @@ export default function NetworkInfoPage() {
         );
         const startTime = performance.now();
         try {
-            const response = await fetch(url, { mode: 'no-cors' }); // Use no-cors for basic reachability
+            await fetch(url, { mode: 'no-cors' }); // Use no-cors for basic reachability
             const endTime = performance.now();
             const latency = Math.round(endTime - startTime);
             setSiteTestResults((prevResults) =>
@@ -197,11 +198,11 @@ export default function NetworkInfoPage() {
                 return (
                     <Badge
                         key={site.url}
-                        variant="secondary"
+                        variant={variant === "success" ? "default" : variant} // 将 success 变体映射为 default 变体
                         className="cursor-pointer flex items-center space-x-1 pr-3"
                         onClick={() => !testingAllSites && testSiteConnectivity(site.url)}
                     >
-                        <img src={site.logo} alt={site.name} className="w-4 h-4 rounded-full" />
+                        <Image src={site.logo} alt={site.name} width={16} height={16} className="w-4 h-4 rounded-full" /> {/* Replace <img> with <Image /> */}
                         <span>{site.name}</span>
                         {pingText && <span className="ml-2 text-xs opacity-75">{pingText}</span>}
                     </Badge>

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -11,7 +11,7 @@ const badgeVariants = cva(
         default:
           "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "border-transparent bg-gray-200 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-100",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
         outline: "text-foreground",

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<React.ElementRef<typeof ProgressPrimitive.Root>, React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>>(
+  ({ className, value, ...props }, ref) => (
+    <ProgressPrimitive.Root
+      ref={ref}
+      className={cn("relative h-2 w-full overflow-hidden rounded-full bg-primary/20", className)}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        className="h-full w-full flex-1 bg-primary transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  )
+)
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -244,7 +244,22 @@ export const toolCategories: ToolCategory[] = [
         url: "/tools/color-palette",
       },
     ],
-  }
+  },
+  {
+    title: "网络工具",
+    description: "网络连接状态检测与网络环境分析工具",
+    icon: Network,
+    url: "#",
+    tools: [
+      {
+        name: "NAT类型检测",
+        title: "NAT类型检测",
+        description: "检测当前网络环境的NAT类型，判断P2P连接能力",
+        path: "/tools/nat-type",
+        url: "/tools/nat-type",
+      }
+    ],
+  },
 ];
 
 // 首页导航项

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -252,6 +252,13 @@ export const toolCategories: ToolCategory[] = [
     url: "#",
     tools: [
       {
+        name: "网络信息",
+        title: "网络信息",
+        description: "IP地址、运营商、地理位置、网络类型等",
+        path: "/tools/network-info",
+        url: "/tools/network-info",
+      },
+      {
         name: "NAT类型检测",
         title: "NAT类型检测",
         description: "检测当前网络环境的NAT类型，判断P2P连接能力",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-popover": "^1.1.6",
+    "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.6
         version: 1.1.6(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.7
+        version: 1.1.7(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.9
         version: 1.2.9(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -478,85 +481,72 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.2':
     resolution: {integrity: sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.2':
     resolution: {integrity: sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.2':
     resolution: {integrity: sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.2':
     resolution: {integrity: sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.2':
     resolution: {integrity: sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.2':
     resolution: {integrity: sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.2':
     resolution: {integrity: sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==}
@@ -629,28 +619,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.3.4':
     resolution: {integrity: sha512-wFyZ7X470YJQtpKot4xCY3gpdn8lE9nTlldG07/kJYexCUpX1piX+MBfZdvulo+t1yADFVEuzFfVHfklfEx8kw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.3.4':
     resolution: {integrity: sha512-gEbH9rv9o7I12qPyvZNVTyP/PWKqOp8clvnoYZQiX800KkqsaJZuOXkWgMa7ANCCh/oEN2ZQheh3yH8/kWPSEg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.3.4':
     resolution: {integrity: sha512-Cf8sr0ufuC/nu/yQ76AnarbSAXcwG/wj+1xFPNbyNo8ltA6kw5d5YqO8kQuwVIxk13SBdtgXrNyom3ZosHAy4A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.3.4':
     resolution: {integrity: sha512-ay5+qADDN3rwRbRpEhTOreOn1OyJIXS60tg9WMYTWCy3fB6rGoyjLVxc4dR9PYjEdR2iDYsaF5h03NA+XuYPQQ==}
@@ -1108,6 +1094,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.7':
+    resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5230,6 +5229,16 @@ snapshots:
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:


### PR DESCRIPTION
调整badge组件和GPU计算器页面的颜色样式，添加深色模式支持.

调整文件：
- app\tools\gpu-calculator\page.tsx
- components\ui\badge.tsx

效果对比：
- 修复前：
<img width="732" height="976" alt="image" src="https://github.com/user-attachments/assets/12269f64-577b-4d62-b212-d9e113d81e62" />

- 修复后：
<img width="730" height="957" alt="image" src="https://github.com/user-attachments/assets/550da817-c0ba-44cf-a11d-7c746ab4f371" />
